### PR TITLE
Clean up `sscg_generator:main/1`

### DIFF
--- a/src/sscg_generator.erl
+++ b/src/sscg_generator.erl
@@ -19,20 +19,13 @@
 main(Args) ->
     check_otp_version(?REQUIRED_OTP_VERSION),
     {ok, _} = application:ensure_all_started(sscg_generator),
-    try
-        cli:run(Args, #{
-            progname => ?MODULE,
-            modules => [?MODULE, 
-                        sscg_generator_generate,
-                        sscg_generator_publish],
-            warn => false
-        })
-    catch
-        Class:Reason:Stacktrace ->
-            cli_abort(Class, Reason, Stacktrace)
-    after
-        application:stop(sscg_generator)
-    end.
+    cli:run(Args, #{
+        progname => ?MODULE,
+        modules => [?MODULE,
+                    sscg_generator_generate,
+                    sscg_generator_publish],
+        warn => false
+    }).
 
 % @private
 cli() ->
@@ -73,6 +66,3 @@ check_otp_version(Desired, Actual) when Actual < Desired ->
     ]);
 check_otp_version(_, _) ->
     ok.
-
-cli_abort(Class, Reason, Stacktrace) ->
-    erlang:raise(Class, Reason, Stacktrace).


### PR DESCRIPTION
Calling `application:stop/1` doesn't seem necessary: The entire VM is going to stop anyway, regardless of whether the CLI command ran successfully or not.
On the other hand, this can log a kinda confusing notice about the application getting stopped.

Additionally, `cli_abort/3` would just raise any caught exception again, which also seems unnecessary -> removed.

Note that `application:stop/1` wouldn't have been called in case of an error anyway, due to the exception that `cli_abort/3` would have raised.